### PR TITLE
fix: score invisible before first judge (#464)

### DIFF
--- a/prpr/src/scene/game.rs
+++ b/prpr/src/scene/game.rs
@@ -367,6 +367,7 @@ impl GameScene {
             }
         }
         ui.alpha(res.alpha, |ui| {
+            ui.text("MAGIC BUGFIX TEXT").color(Color::new(0., 0., 0., 0.)).draw();
             if tm.now() as f32 - self.pause_first_time <= PAUSE_CLICK_INTERVAL {
                 ui.fill_circle(pause_center.x, pause_center.y, 0.05, Color::new(1., 1., 1., 0.5));
             }
@@ -428,6 +429,8 @@ impl GameScene {
                             .draw_using(&PGR_FONT);
                     });
             }
+            // magic to make score visible, refer to phira/src/rate.rs#L219
+            ui.text("").draw_using(&PGR_FONT);
             let lf = -1. + margin;
             let bt = -top - eps * 2.8 + (1. - p) * 0.4;
             let ct = ui.text(&res.info.name).measure().center();


### PR DESCRIPTION
* fix: score invisible before first judge

* fix: first text can't be rendered properly

fixed by drawing a transparent text before any text is drawn